### PR TITLE
fix: Allow the polyfill to update 'aria-level' again, after the first time

### DIFF
--- a/headingoffset-polyfill.test.html
+++ b/headingoffset-polyfill.test.html
@@ -38,7 +38,7 @@
             expect("headingOffset" in container).to.equal(true);
           });
           it("default value when unset", () => {
-            expect(container.headingOffset).to.equal("0");
+            expect(container.headingOffset).to.equal(0);
           });
           it("setting via JS affects HTML", () => {
             container.headingOffset = 1;
@@ -52,7 +52,7 @@
           });
           it("setting via HTML affects JS", () => {
             container.setAttribute("headingoffset", "2");
-            expect(container.headingOffset).to.equal("2");
+            expect(container.headingOffset).to.equal(2);
           });
         });
 
@@ -144,6 +144,47 @@
             container.appendChild(h2);
             await new Promise((resolve) => setTimeout(resolve, 0));
             expect(h2.getAttribute("aria-level")).to.equal("3");
+          });
+          it("deeply nested, 1 offset (grandchild has the attribute)", async () => {
+            await setup({
+              innerHTML: `
+                <div>
+                  <div headingoffset="1">
+                    <h1 id="h1">Level 2</h1>
+                  </div>
+                </div>`,
+            });
+            expect(h1.getAttribute("aria-level")).to.equal("2");
+          });
+          it("nested, 1 offset (offset updated later)", async () => {
+            await setup({
+              headingOffset: 1,
+              innerHTML: `
+               <h1 id="h1A" aria-level="1">Level 1</h1>
+               <h1 id="h1B">Level 2</h1>`,
+            });
+            expect(h1A.getAttribute("aria-level")).to.equal("1");
+            expect(h1B.getAttribute("aria-level")).to.equal("2");
+            container.headingOffset = 2;
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            expect(h1A.getAttribute("aria-level")).to.equal("1");
+            expect(h1B.getAttribute("aria-level")).to.equal("3");
+          });
+          it("nested, 1 offset (aria-level updated later (not by polyfill))", async () => {
+            await setup({
+              headingOffset: 1,
+              innerHTML: `
+               <h1 id="h1A" aria-level="1">Level 1</h1>
+               <h1 id="h1B">Level 2</h1>`,
+            });
+            expect(h1A.getAttribute("aria-level")).to.equal("1");
+            expect(h1B.getAttribute("aria-level")).to.equal("2");
+            h1A.setAttribute("aria-level", "6");
+            h1B.setAttribute("aria-level", "6");
+            container.headingOffset = 2;
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            expect(h1A.getAttribute("aria-level")).to.equal("6");
+            expect(h1B.getAttribute("aria-level")).to.equal("6");
           });
         });
 


### PR DESCRIPTION
Modifies the early return when 'aria-level' is already set to distinguish between user-set and polyfill-set values.