### PR TITLE
fix: Substitute negative and invalid values (e.g. `"fish"` in `headingoffset="fish"`) with the default value (`0`)

### DIFF
--- a/headingoffset-polyfill.js
+++ b/headingoffset-polyfill.js
@@ -27,7 +27,7 @@ if (!("headingOffset" in Element.prototype)) {
     get: function () {
       const defaultValue = 0;
       const value = Number(this.getAttribute("headingoffset"));
-      return Number.isNaN(value) ? defaultValue : value;
+      return !Number.isNaN(value) && value > 0 ? value : defaultValue;
     },
     set: function (headingOffset) {
       if (

--- a/headingoffset-polyfill.js
+++ b/headingoffset-polyfill.js
@@ -25,8 +25,9 @@ if (!("headingOffset" in Element.prototype)) {
   Object.defineProperty(Element.prototype, "headingOffset", {
     enumerable: true,
     get: function () {
-      const value = Number(this.getAttribute("headingoffset") ?? 0);
-      return Number.isNaN(value) ? 0 : value;
+      const defaultValue = 0;
+      const value = Number(this.getAttribute("headingoffset"));
+      return Number.isNaN(value) ? defaultValue : value;
     },
     set: function (headingOffset) {
       if (

--- a/headingoffset-polyfill.js
+++ b/headingoffset-polyfill.js
@@ -25,7 +25,8 @@ if (!("headingOffset" in Element.prototype)) {
   Object.defineProperty(Element.prototype, "headingOffset", {
     enumerable: true,
     get: function () {
-      return Number(this.getAttribute("headingoffset") ?? 0);
+      const value = Number(this.getAttribute("headingoffset") ?? 0);
+      return Number.isNaN(value) ? 0 : value;
     },
     set: function (headingOffset) {
       if (

--- a/headingoffset-polyfill.test.html
+++ b/headingoffset-polyfill.test.html
@@ -40,6 +40,10 @@
           it("default value when unset", () => {
             expect(container.headingOffset).to.equal(0);
           });
+          it("default value when invalid", () => {
+            container.headingOffset = "fish";
+            expect(container.headingOffset).to.equal(0);
+          });
           it("setting via JS affects HTML", () => {
             container.headingOffset = 1;
             expect(container.getAttribute("headingoffset")).to.equal("1");

--- a/headingoffset-polyfill.test.html
+++ b/headingoffset-polyfill.test.html
@@ -44,9 +44,9 @@
             container.headingOffset = "fish";
             expect(container.headingOffset).to.equal(0);
           });
-          it("allows negative values", () => {
+          it("default value when negative", () => {
             container.headingOffset = -1;
-            expect(container.headingOffset).to.equal(-1);
+            expect(container.headingOffset).to.equal(0);
           });
           it("setting via JS affects HTML", () => {
             container.headingOffset = 1;

--- a/headingoffset-polyfill.test.html
+++ b/headingoffset-polyfill.test.html
@@ -44,6 +44,10 @@
             container.headingOffset = "fish";
             expect(container.headingOffset).to.equal(0);
           });
+          it("allows negative values", () => {
+            container.headingOffset = -1;
+            expect(container.headingOffset).to.equal(-1);
+          });
           it("setting via JS affects HTML", () => {
             container.headingOffset = 1;
             expect(container.getAttribute("headingoffset")).to.equal("1");


### PR DESCRIPTION
Fixes #13 